### PR TITLE
Add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  citation:
+    image: citation
+    ports:
+      - "80:4000"
+    restart: always


### PR DESCRIPTION
- setup `docker-compose.yml` file for default configuration of citation.

It's possible to setup default configuration for wordpress backend or another CMS backend.
I may add information in ReadMe.