### PR TITLE
Use new base image for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,4 @@
-FROM node:7.6-slim
-
-# Enviroment variables
-ENV HOMEDIR /data
-RUN apt-get update && apt-get install -y \
-	build-essential \
-	libssl-dev \
-	git \
-	&& mkdir -p ${HOMEDIR}
-WORKDIR ${HOMEDIR}
+FROM slashgear/citation-base
 
 # install all dependencies
 ADD package.json ./


### PR DESCRIPTION
- In order to make build more efficient, I made an docker image
with all init layers of citation. Thoses layers are not going to change
soon. Those steps will now be done in [citation-base](https://github.com/Slashgear/citation-base) image build.

- `citation-base` build is defined in one of my repository but you could fork it, if you prefer owning it.

- 🐳  [docker hub image](https://hub.docker.com/r/slashgear/citation-base/)