### PR TITLE
Graph ql inspect with model

### DIFF
--- a/citation-server/src/gitasdb/inspect.js
+++ b/citation-server/src/gitasdb/inspect.js
@@ -6,14 +6,21 @@ import mergeDeep from 'merge-deep';
 import winston from 'winston';
 
 import conf from '../conf';
+import {getTypesNames} from '../graphql/model';
 
 const logger = winston.loggers.get('GitAsDb');
 
+let modelTypes;
+
 function includesLink(stack, link) {
+	if (!modelTypes.includes(link.collection)) {
+		return true;
+	}
 	return stack.filter(stackLink => stackLink.collection === link.collection && stackLink.id === link.id).length > 0;
 }
 
 export async function inspectObject(type, id, stack = []) {
+	modelTypes = await getTypesNames();
 	try {
 		logger.debug(`inspect object ${type} ${id}`);
 		const objectPath = path.resolve(conf.work.content, conf.content.branch, type, id);

--- a/citation-server/src/gitasdb/inspect.js
+++ b/citation-server/src/gitasdb/inspect.js
@@ -6,7 +6,7 @@ import mergeDeep from 'merge-deep';
 import winston from 'winston';
 
 import conf from '../conf';
-import {getTypesNames} from '../graphql/model';
+import { getTypesNames } from '../graphql/model';
 
 const logger = winston.loggers.get('GitAsDb');
 

--- a/citation-server/src/gitasdb/inspect.test.js
+++ b/citation-server/src/gitasdb/inspect.test.js
@@ -46,6 +46,20 @@ test('inspectObject should follow unique link', async t => {
 	t.deepEqual(result, ['one', { two: ['three', 'four'] }]);
 });
 
+test('inspectObject should ignore link if type is not in the model', async t => {
+	const links = {
+		__role__: 'link',
+		link: {
+			collection: 'LinkedType3',
+			id: 'LinkedId'
+		}
+	};
+	readdir.onCall(0).returns(Promise.resolve(['one.md', 'two.json']));
+	readFile.onCall(0).returns(Promise.resolve(new Buffer(JSON.stringify(links))));
+	const result = await inspect.inspectObject('Type', 'id');
+	t.deepEqual(result, ['one']);
+});
+
 test('inspectObject should follow multiple links', async t => {
 	const links = {
 		__role__: 'links',

--- a/citation-server/src/gitasdb/inspect.test.js
+++ b/citation-server/src/gitasdb/inspect.test.js
@@ -5,12 +5,15 @@ import sinon from 'sinon';
 let inspect;
 let readdir;
 let readFile;
+let getTypesNames;
 
 test.beforeEach(() => {
 	readdir = sinon.stub().returns(Promise.resolve([]));
 	readFile = sinon.stub().returns(Promise.resolve(new Buffer('')));
+	getTypesNames = sinon.stub().returns(['Type', 'LinkedType', 'LinkedType1', 'LinkedType2']);
 	inspect = proxyquire('./inspect', {
 		'fs-promise': { readdir, readFile },
+		'../graphql/model': { getTypesNames },
 		winston: { loggers: { get: () => ({ debug: () => {}, error: () => {} }) } }
 	});
 });

--- a/citation-server/src/graphql/model.js
+++ b/citation-server/src/graphql/model.js
@@ -1,6 +1,5 @@
 import path from 'path';
 
-import _ from 'lodash';
 import fs from 'fs-promise';
 
 import conf from '../conf';
@@ -23,4 +22,9 @@ export async function writeModel(newModel) {
 	const result = await fs.writeJSON(modelPath, newModel.schema.types);
 	await updateSchema();
 	return result;
+}
+
+export async function getTypesNames() {
+	const model = await readModel();
+	return model.map(type => type.name);
 }

--- a/citation-server/src/graphql/model.test.js
+++ b/citation-server/src/graphql/model.test.js
@@ -12,16 +12,16 @@ test.beforeEach(() => {
 	readJson = sinon.stub().returns(Promise.resolve([]));
 	resolve = sinon.stub().returns(Promise.resolve([]));
 	model = proxyquire('./model', {
-		'./constants': {workingDirectory},
-		'fs-promise': {readJson},
-		path: {resolve},
-		winston: {loggers: {get: () => ({debug: () => {}, error: () => {}})}}
+		'./constants': { workingDirectory },
+		'fs-promise': { readJson },
+		path: { resolve },
+		winston: { loggers: { get: () => ({ debug: () => {}, error: () => {} }) } }
 	});
 });
 
 test('getTypesNames function should return only type names from the model', async t => {
-	const firstSchema = [{name: 'type1', fields: 'fields'}, {name: 'type2', fields: 'fields'}];
-	const secondSchema = [{name: 'type3', fields: 'fields'}];
+	const firstSchema = [{ name: 'type1', fields: 'fields' }, { name: 'type2', fields: 'fields' }];
+	const secondSchema = [{ name: 'type3', fields: 'fields' }];
 	const expectedResult = ['type3', 'type1', 'type2'];
 	resolve.returns('modelPath1');
 	resolve.withArgs('../citation-server/src/sources/sources.json').returns('modelPath2');

--- a/citation-server/src/graphql/model.test.js
+++ b/citation-server/src/graphql/model.test.js
@@ -1,0 +1,31 @@
+import test from 'ava';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const workingDirectory = 'workingDirectory';
+
+let readJson;
+let resolve;
+let model;
+
+test.beforeEach(() => {
+	readJson = sinon.stub().returns(Promise.resolve([]));
+	resolve = sinon.stub().returns(Promise.resolve([]));
+	model = proxyquire('./model', {
+		'./constants': {workingDirectory},
+		'fs-promise': {readJson},
+		path: {resolve},
+		winston: {loggers: {get: () => ({debug: () => {}, error: () => {}})}}
+	});
+});
+
+test('getTypesNames function should return only type names from the model', async t => {
+	const firstSchema = [{name: 'type1', fields: 'fields'}, {name: 'type2', fields: 'fields'}];
+	const secondSchema = [{name: 'type3', fields: 'fields'}];
+	const expectedResult = ['type3', 'type1', 'type2'];
+	resolve.returns('modelPath1');
+	resolve.withArgs('../citation-server/src/sources/sources.json').returns('modelPath2');
+	readJson.withArgs('modelPath1').returns(firstSchema);
+	readJson.withArgs('modelPath2').returns(secondSchema);
+	t.deepEqual(await model.getTypesNames(), expectedResult);
+});


### PR DESCRIPTION
The inspect function will no longer try to recursively inspect types which are not in the model. 