### PR TITLE
Handle empty content repository

### DIFF
--- a/citation-react-renderer/src/index.js
+++ b/citation-react-renderer/src/index.js
@@ -23,6 +23,9 @@ export default async function render(options) {
 	logger.debug(`${context.pages.length} root pages loaded`);
 
 	context.urls = await urls(context.pages);
+	if (context.urls.length === 0) {
+		context.urls = [{ url: '', pages: [] }];
+	}
 	logger.debug(`${context.urls.length} urls computed`);
 
 	context.contents = await load(options.serverUrl, context.pages);

--- a/citation-react-router/src/Routes.js
+++ b/citation-react-router/src/Routes.js
@@ -5,6 +5,7 @@ import { Route, Switch } from 'react-router-dom';
 import { queryComponentTree } from './queries';
 import ComponentTree from './components/ComponentTree';
 import { chooseColorForComponents } from './edition/colors';
+import Empty from './empty/Empty';
 
 export default class Routes extends Component {
 	static propTypes = {
@@ -63,6 +64,9 @@ export default class Routes extends Component {
 	}
 
 	render() {
+		if (this.props.pages.length === 0) {
+			return <Empty />;
+		}
 		return (
 			<Switch>
 				{this.props.pages.reverse().map((page, i) => {

--- a/citation-react-router/src/empty/Empty.js
+++ b/citation-react-router/src/empty/Empty.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const styles = {
+	container: {
+		display: 'flex',
+		paddingTop: '5rem',
+		flexDirection: 'column',
+		alignItems: 'center'
+	},
+	title: {}
+};
+
+const Empty = () =>
+	<main style={styles.container}>
+		<h1>Welcome to Citation!</h1>
+		<p>Your site configuration seems empty.</p>
+		<p>You should go to the administration to create your first pages</p>
+		<p><a href="/admin">Administration</a></p>
+	</main>;
+
+export default Empty;

--- a/citation-server/src/gitasdb/model.js
+++ b/citation-server/src/gitasdb/model.js
@@ -7,8 +7,15 @@ import { updateSchema } from '../index';
 
 export async function readModel() {
 	const modelPath = path.resolve(conf.work.content, conf.content.branch, 'model.json');
+	let modelTypes;
+	try {
+		modelTypes = await fs.readJson(modelPath);
+	} catch (e) {
+		modelTypes = [];
+	}
 	const sourcesPath = path.resolve('../citation-server/src/sources/sources.json');
-	return Array.prototype.concat(await fs.readJson(sourcesPath), await fs.readJson(modelPath));
+	const sourcesTypes = await fs.readJson(sourcesPath);
+	return [...sourcesTypes, ...modelTypes];
 }
 
 export async function writeModel(newModel) {

--- a/citation-server/src/gitasdb/model.test.js
+++ b/citation-server/src/gitasdb/model.test.js
@@ -27,11 +27,18 @@ test('readModel should return data from sources and model', async t => {
 		{ name: 'type1', fields: 'fields' },
 		{ name: 'type2', fields: 'fields' }
 	];
-	resolve.returns('modelPath1');
-	resolve.withArgs('../citation-server/src/sources/sources.json').returns('modelPath2');
-	readJson.withArgs('modelPath1').returns(firstSchema);
-	readJson.withArgs('modelPath2').returns(secondSchema);
+	resolve.returns('modelPath');
+	readJson.onCall(0).returns(firstSchema);
+	readJson.onCall(1).returns(secondSchema);
 	t.deepEqual(await model.readModel(), expectedResult);
+});
+
+test('readModel should not fail if there is no model.json file', async t => {
+	const schema = [{ name: 'type1', fields: 'fields' }];
+	resolve.returns('modelPath');
+	readJson.onCall(0).returns(Promise.reject());
+	readJson.onCall(1).returns(schema);
+	t.deepEqual(await model.readModel(), schema);
 });
 
 test('getTypesNames function should return only type names from the model', async t => {

--- a/citation-server/src/gitasdb/read.js
+++ b/citation-server/src/gitasdb/read.js
@@ -15,8 +15,8 @@ export async function readCollection(type) {
 		const collectionFolders = await fs.readdir(collectionPath);
 		return await Promise.all(collectionFolders.map(folder => readObject(type, folder)));
 	} catch (error) {
-		logger.error('Gitasdb read collection error', error);
-		throw error;
+		logger.debug('GitAsDb read collection', error);
+		return [];
 	}
 }
 
@@ -43,7 +43,7 @@ export async function readObject(type, id) {
 		});
 		return object;
 	} catch (error) {
-		logger.debug('Gitasdb read object error', error);
+		logger.debug('GitAsDb read object', error);
 		return null;
 	}
 }

--- a/citation-server/src/graphql/mutation.js
+++ b/citation-server/src/graphql/mutation.js
@@ -7,7 +7,7 @@ import winston from 'winston';
 
 import { writeObject } from '../gitasdb/write';
 import { deleteObject } from '../gitasdb/delete';
-import { readModel, writeModel } from './model';
+import { readModel, writeModel } from '../gitasdb/model';
 
 const logger = winston.loggers.get('GraphQL');
 

--- a/citation-server/src/graphql/mutation.test.js
+++ b/citation-server/src/graphql/mutation.test.js
@@ -21,7 +21,7 @@ test.beforeEach(() => {
 		])
 	);
 	mutation = proxyquire('./mutation', {
-		'./model': { readModel },
+		'../gitasdb/model': { readModel },
 		winston: { loggers: { get: () => ({ debug: () => {}, error: () => {} }) } }
 	});
 });

--- a/citation-server/src/graphql/query.js
+++ b/citation-server/src/graphql/query.js
@@ -11,7 +11,7 @@ import {
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 
-import { readModel, getTypesNames } from './model';
+import { readModel, getTypesNames } from '../gitasdb/model';
 import { read, readChild, readChildren, readMap, inspect } from './resolve';
 
 const RichTextType = new GraphQLScalarType({
@@ -64,7 +64,10 @@ export async function buildObjects() {
 				return { type, resolve: root => readChild(root[field.name]) };
 			case 'links':
 				type = field.type[1] === '*' ? new GraphQLList(ObjectInterface) : new GraphQLList(ObjectTypes[field.type[1]]);
-				return { type, resolve: root => readChildren(root[field.name], modelTypes) };
+				return {
+					type,
+					resolve: root => readChildren(root[field.name], modelTypes)
+				};
 			case 'map':
 				return {
 					type: new GraphQLList(KeyValuePair),

--- a/citation-server/src/graphql/query.test.js
+++ b/citation-server/src/graphql/query.test.js
@@ -54,7 +54,7 @@ test.beforeEach(async () => {
 		])
 	);
 	query = proxyquire('./query', {
-		'./model': { readModel },
+		'../gitasdb/model': { readModel },
 		winston: { loggers: { get: () => ({ debug: () => {}, error: () => {} }) } }
 	});
 	result = await query.buildObjects();


### PR DESCRIPTION
Create the workflow to start a project from scratch easily

- Handle not having a `model.json` in the git content repo
- Handle a type folder not to exists
- Router to render an default "empty" page when apis returns 0 page

Better than creating a initialization workflow, I chose to handle the empty content state. It's more in the spirit of the rest of the code.

This PR could stop there but it will still be necessary to handle the first page creation in the sitemap backoffice.